### PR TITLE
remove duplicate tamper product to fix e2e test failure

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -104,11 +104,6 @@ products:
     price: 5.09
   - name: "Mozilla Horizontal T-Shirt"
     price: 5.94
-  - name: 'OWASP SSL Advanced Forensic Tool (O-Saft)'
-    description: 'O-Saft is an easy to use tool to show information about SSL certificate and tests the SSL connection according given list of ciphers and various SSL configurations.'
-    price: 0.01
-    image: 'owasp_osaft.jpg'
-    useForProductTamperingChallenge: true
   - name: 'OWASP Zed Attack Proxy (ZAP)'
     description: "ZAP is one of the world’s most popular free security tools and can help you automatically find security vulnerabilities while you are developing and testing your applications."
     price: 0.01

--- a/test/api/productApiSpec.js
+++ b/test/api/productApiSpec.js
@@ -138,7 +138,7 @@ describe('/rest/product/search', () => {
   })
 
   it('GET product search with one match returns found product', done => {
-    frisby.get(REST_URL + '/product/search?q=o-saft')
+    frisby.get(REST_URL + '/product/search?q=zap')
       .expect('status', 200)
       .expect('header', 'content-type', /application\/json/)
       .then(res => {


### PR DESCRIPTION
This should get e2e tests passing when paired with #9 or the equivalent upstream change.

Changes:

* remove the osaft product
* update the product search query to zap from o-saft to get the frisby test to pass again 

Having two tamper products breaks the e2e test unauthed "changeProduct" challenge in the following way:

1. [the change product test](https://github.com/mozilla/ctf-austin/blob/df732a9bafb28f6e0c8fb3287236e99995a0497b/test/e2e/restApiSpec.js#L37-L47) uses [the first product ID (in this case osaft with id 26)](https://github.com/mozilla/ctf-austin/blob/df732a9bafb28f6e0c8fb3287236e99995a0497b/test/e2e/restApiSpec.js#L2-L8
)
2. data creator [appends an osaft link to the description of products tagged useForProductTamperingChallenge](https://github.com/mozilla/ctf-austin/blob/df732a9bafb28f6e0c8fb3287236e99995a0497b/data/datacreator.js#L629) and caches the last one as [products.osaft](https://github.com/mozilla/ctf-austin/blob/df732a9bafb28f6e0c8fb3287236e99995a0497b/data/datacreator.js#L657-L658
) (in this case zap with id 27)
3. so even though the test changes the osaft product, the scoreboard didn't update since it was [looking for changes to products.osaft / zap](https://github.com/mozilla/ctf-austin/blob/df732a9bafb28f6e0c8fb3287236e99995a0497b/routes/verify.js#L45-L49) and the test failed